### PR TITLE
Fixing Notifications

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -173,7 +173,6 @@ header {
   align-items: center;
   grid-area: header;
   gap: 1rem;
-  overflow: hidden;
 }
 
 /* Header Text */
@@ -206,6 +205,11 @@ header nav .search-box {
   gap: 1rem;
   justify-content: flex-end;
   transition: var(--transition);
+  overflow-x: hidden;
+}
+
+header nav .search-box.open {
+  overflow-x: visible;
 }
 
 header .search-box label {


### PR DESCRIPTION
- Removed `overflow: hidden;` from the header.
- Applied overflow management directly on the `search-box` instead:
  - When the `search-box` does not have the `open` class, `overflow-x` is set to `hidden`.
  - When the `search-box` has the `open` class, `overflow-x` is set to `visible`.

This change ensures that the header does not cut off any elements while maintaining proper visibility control for the search box.